### PR TITLE
[Client] Feat/Sub-Navigation : Sidebar에서도 기능 구현

### DIFF
--- a/client/src/components/navigation/Navbar.js
+++ b/client/src/components/navigation/Navbar.js
@@ -6,7 +6,7 @@ import { clearSession } from '../../lib/clearSession';
 import { requestSignOut } from '../../lib/requestUserInfo';
 import { checkUserIsLogin, checkUserNickname } from '../../lib/checkIsLogin';
 import { FaBars } from 'react-icons/fa';
-import { Nav, NavbarContainer, NavLogo, MobileIcon, NavMenu, NavItem, NavLinks, NavBtn, NavSignInBtn, SubNavigation } from './NavbarElements';
+import { Nav, NavbarContainer, NavLogo, MobileIcon, NavMenu, NavItem, NavLinks, NavBtnWrap, NavSignInBtn, SubNavigation } from './NavbarElements';
 
 const Navbar = ({ handleSidebar }) => {
   const dispatch = useDispatch();
@@ -45,7 +45,7 @@ const Navbar = ({ handleSidebar }) => {
             <NavItem>
               <NavLinks to="/cheatsheet">자습서</NavLinks>
             </NavItem>
-            <NavBtn>
+            <NavBtnWrap>
               {isLogin ? <NavSignInBtn onClick={handleSubNavi}>{nickname}</NavSignInBtn> : <NavSignInBtn onClick={() => dispatch(setModal('signIn'))}>로그인</NavSignInBtn>}
               {isOpen ? (
                 <SubNavigation>
@@ -55,7 +55,7 @@ const Navbar = ({ handleSidebar }) => {
                   <div onClick={handleSignOut}>로그아웃</div>
                 </SubNavigation>
               ) : null}
-            </NavBtn>
+            </NavBtnWrap>
           </NavMenu>
         </NavbarContainer>
       </Nav>

--- a/client/src/components/navigation/NavbarElements.js
+++ b/client/src/components/navigation/NavbarElements.js
@@ -96,7 +96,7 @@ export const NavLinks = styled(LinkS)`
   } */
 `;
 
-export const NavBtn = styled.nav`
+export const NavBtnWrap = styled.nav`
   display: flex;
   align-items: center;
   margin-right: 30px;

--- a/client/src/components/navigation/Sidebar.js
+++ b/client/src/components/navigation/Sidebar.js
@@ -1,11 +1,23 @@
 import React from 'react';
 import { useDispatch } from 'react-redux';
+import { useNavigate } from 'react-router-dom';
 import { setModal } from '../../modules/modal';
-import { SidebarContainer, Icon, CloseIcon, SidebarWrapper, SidebarMenu, SidebarLink, SidebarBtnWrap, SidebarBtn } from './SidebarElements';
 import { clearSession } from '../../lib/clearSession';
+import { requestSignOut } from '../../lib/requestUserInfo';
+import { checkUserIsLogin, checkUserNickname } from '../../lib/checkIsLogin';
+import { SidebarContainer, Icon, CloseIcon, SidebarWrapper, SidebarMenu, SidebarLink, SidebarBtnWrap, SidebarBtn, SubSidebar, SidebarSignOut } from './SidebarElements';
 
 const Sidebar = ({ openSidebar, handleSidebar }) => {
   const dispatch = useDispatch();
+  const isLogin = checkUserIsLogin();
+  const navigate = useNavigate();
+  const nickname = checkUserNickname();
+  const handleSignOut = async () => {
+    const serverResult = await requestSignOut();
+    if (serverResult) {
+      navigate('/');
+    }
+  };
 
   return (
     <SidebarContainer openSidebar={openSidebar}>
@@ -14,21 +26,21 @@ const Sidebar = ({ openSidebar, handleSidebar }) => {
       </Icon>
       <SidebarWrapper>
         <SidebarMenu onClick={() => handleSidebar(false)}>
+          <SidebarBtnWrap>
+            {isLogin ? <SidebarBtn onClick={() => (window.location.href = '/myinfo')}>{nickname}</SidebarBtn> : <SidebarBtn onClick={() => dispatch(setModal('signIn'))}>로그인</SidebarBtn>}
+          </SidebarBtnWrap>
           <SidebarLink to="/tutorial">학습하기</SidebarLink>
           <SidebarLink to="/quizlist" onClick={() => clearSession()}>
             퀴즈
           </SidebarLink>
-          <SidebarLink to="/cheatsheet">자습서</SidebarLink>
-          <SidebarBtnWrap>
-            <SidebarBtn
-              onClick={() => {
-                handleSidebar(false);
-                dispatch(setModal('signIn'));
-              }}
-            >
-              로그인
-            </SidebarBtn>
-          </SidebarBtnWrap>
+          {isLogin ? (
+            <SubSidebar>
+              <SidebarLink to="/myinfo">내 정보</SidebarLink>
+              <SidebarSignOut onClick={handleSignOut}>로그아웃</SidebarSignOut>
+            </SubSidebar>
+          ) : (
+            <></>
+          )}
         </SidebarMenu>
       </SidebarWrapper>
     </SidebarContainer>

--- a/client/src/components/navigation/SidebarElements.js
+++ b/client/src/components/navigation/SidebarElements.js
@@ -83,7 +83,7 @@ export const SidebarBtn = styled.button`
   border-radius: 40px;
   background: #fff;
   white-space: nowrap;
-  padding: 24px 50px;
+  padding: 10px 40px;
   color: #000;
   font-size: 25px;
   outline: none;
@@ -97,4 +97,30 @@ export const SidebarBtn = styled.button`
     background: ;
     color: ;
   } */
+`;
+
+export const SidebarSignOut = styled.div`
+  display: felx;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.5rem;
+  text-decoration: none;
+  list-style: none;
+  transition: 0.2s ease-in-out;
+  text-decoration: none;
+  color: #fff;
+  cursor: pointer;
+`;
+
+export const SubSidebar = styled.div`
+  /* display: felx;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.5rem;
+  text-decoration: none;
+  list-style: none;
+  transition: 0.2s ease-in-out;
+  text-decoration: none;
+  color: #fff;
+  cursor: pointer; */
 `;


### PR DESCRIPTION
* Feat: 로그인하면 로그인 버튼 닉네임으로 변경(OAuth 로그인일때도 닉네임 받아옴)
* "내 정보" - 내 정보 조회 페이지로 이동 및 SubNavigation 닫힘
* "로그아웃" - 토큰 삭제 되고 홈으로 돌아감
* Sidebar에서도 기능 구현
  -로그인 시 로그인 버튼 닉네임으로 변경
  -닉네임 버튼 누르면 내 정보 조회 페이지로
  -로그인하면 "내 정보", "로그아웃" 보임
  -로그아웃하면 "로그인" 버튼, 학습하기, 퀴즈 만 보임