### PR TITLE
[Client] Bugfix/사파리, 모바일 크롬에서 보이지 않는 버그 수정

### DIFF
--- a/client/src/components/navigation/index.js
+++ b/client/src/components/navigation/index.js
@@ -20,10 +20,10 @@ const Navigation = () => {
 
   useEffect(() => {
     const url = new URL(window.location.href);
-    const urlParserReg = /(?<=state=)([a-z]+)/;
+    const urlParserReg = /state=([a-z]+)/;
 
     if (urlParserReg.test(url.search)) {
-      const state = urlParserReg.exec(url.search)[0];
+      const state = urlParserReg.exec(url.search)[1];
 
       if (state === 'kakao') {
         kakaoCallback(url);

--- a/client/src/lib/requestUserInfo.js
+++ b/client/src/lib/requestUserInfo.js
@@ -111,11 +111,11 @@ export const requestGetMyInfo = async () => {
 export const requestSetNewPassword = async (userInfo) => {
   const { newPassword } = userInfo;
   const url = new URL(window.location.href);
-  const urlParserReg = /(?<=state=)([a-z]+)/;
+  const urlParserReg = /state=([a-z]+)/;
 
   try {
     if (urlParserReg.test(url.search)) {
-      const state = urlParserReg.exec(url.search)[0];
+      const state = urlParserReg.exec(url.search)[1];
 
       if (state === 'findpassword') {
         const token = url.search.split('=')[1].split('&')[0];


### PR DESCRIPTION
# urlParserReg-lookbehind-remove
사파리, 모바일 크롬에선 lookbehind 기능이 지원하지 않음

* Before
```js
  useEffect(() => {
    const url = new URL(window.location.href);
    const urlParserReg = /(?<=state=)([a-z]+)/; <<<<<<<<<<<<

    if (urlParserReg.test(url.search)) {
      const state = urlParserReg.exec(url.search)[0];
```

* After
```js
  useEffect(() => {
    const url = new URL(window.location.href);
    const urlParserReg = /state=([a-z]+)/;

    if (urlParserReg.test(url.search)) {
      const state = urlParserReg.exec(url.search)[1];

```
